### PR TITLE
Mention the `--diff` flag for `format --check`

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ you can use the `args` input to overwrite the default value (`check`):
 ```yaml
 - uses: astral-sh/ruff-action@v3
   with:
-    args: "format --check"
+    args: "format --check --diff"
 ```
 
 ### Install specific versions


### PR DESCRIPTION
Just like for the action run adding annotations, the CI is the place where you'd want extra information.

Especially information that tells you *how* to fix an issue, which is relevant when a contributor doesn't want to / can't run the tool locally (an edit through the GitHub UI could be more convenient, don't want to bother installing extra tools locally, they're having issues not picking up the right Ruff version when ran locally, etc.)

It's also easier to opt-out of copy-pasting this flag, than not knowing about it in the first place.

Hence I think this documentation change is a positive to help anyone integrate this action into their CI for check+formatting by looking at the readme.