### PR TITLE
Add support for reading the ruff version from Poetry groups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -276,6 +276,7 @@ jobs:
       - test-default-version-from-pyproject
       - test-default-version-from-pyproject-dev-group
       - test-default-version-from-pyproject-dependency-groups
+      - test-default-version-from-pyproject-poetry-groups
       - test-default-version-from-pyproject-optional-dependencies
       - test-default-version-from-requirements
       - test-semver-range

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,6 +118,23 @@ jobs:
           fi
         env:
           RUFF_VERSION: ${{ steps.ruff-action.outputs.ruff-version }}
+  test-default-version-from-pyproject-poetry-groups:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use default version from pyproject.toml poetry group dependencies
+        id: ruff-action
+        uses: ./
+        with:
+          src: __tests__/fixtures/pyproject-dependency-poetry-project
+          version-file: __tests__/fixtures/pyproject-dependency-poetry-project/pyproject.toml
+      - name: Correct version gets installed
+        run: |
+          if [ "$RUFF_VERSION" != "0.8.3" ]; then
+            exit 1
+          fi
+        env:
+          RUFF_VERSION: ${{ steps.ruff-action.outputs.ruff-version }}
   test-default-version-from-pyproject-optional-dependencies:
     runs-on: ubuntu-latest
     steps:

--- a/__tests__/fixtures/pyproject-dependency-poetry-project/pyproject.toml
+++ b/__tests__/fixtures/pyproject-dependency-poetry-project/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "pyproject-dependency-poetry-project"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.12"
+
+[tool.poetry.group.dev.dependencies]
+sphinx = "*"
+ruff = "0.8.3"
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/__tests__/fixtures/pyproject-dependency-poetry-project/src/pyproject_dependency_dev_project/__init__.py
+++ b/__tests__/fixtures/pyproject-dependency-poetry-project/src/pyproject_dependency_dev_project/__init__.py
@@ -1,0 +1,2 @@
+def hello() -> str:
+    return "Hello from python-project!"

--- a/__tests__/fixtures/pyproject-dependency-poetry-project/src/pyproject_dependency_dev_project/hello_world.py
+++ b/__tests__/fixtures/pyproject-dependency-poetry-project/src/pyproject_dependency_dev_project/hello_world.py
@@ -1,0 +1,1 @@
+print("Hello world!")

--- a/dist/ruff-action/index.js
+++ b/dist/ruff-action/index.js
@@ -30938,7 +30938,7 @@ function parsePyproject(pyprojectContent) {
         return version;
     // Special handling for Poetry until it supports PEP 735
     // See: <https://github.com/python-poetry/poetry/issues/9751>
-    const poetryGroups = Object.values(pyproject?.tool?.poetry?.group ?? {});
+    const poetryGroups = Object.values(pyproject?.tool?.poetry?.group || {});
     return poetryGroups
         .flatMap((group) => Object.entries(group.dependencies))
         .map(([name, spec]) => {

--- a/dist/ruff-action/index.js
+++ b/dist/ruff-action/index.js
@@ -30933,9 +30933,9 @@ function parsePyproject(pyprojectContent) {
     const devDependencies = Object.values(pyproject?.["dependency-groups"] || {})
         .flat()
         .filter((item) => typeof item === "string");
-    const version = getRuffVersionFromAllDependencies(dependencies.concat(optionalDependencies, devDependencies));
-    if (version)
-        return version;
+    return (getRuffVersionFromAllDependencies(dependencies.concat(optionalDependencies, devDependencies)) || getRuffVersionFromPoetryGroups(pyproject));
+}
+function getRuffVersionFromPoetryGroups(pyproject) {
     // Special handling for Poetry until it supports PEP 735
     // See: <https://github.com/python-poetry/poetry/issues/9751>
     const poetryGroups = Object.values(pyproject?.tool?.poetry?.group || {});

--- a/src/utils/pyproject.ts
+++ b/src/utils/pyproject.ts
@@ -47,11 +47,16 @@ function parsePyproject(pyprojectContent: string): string | undefined {
   )
     .flat()
     .filter((item: string | object) => typeof item === "string");
-  const version = getRuffVersionFromAllDependencies(
-    dependencies.concat(optionalDependencies, devDependencies),
+  return (
+    getRuffVersionFromAllDependencies(
+      dependencies.concat(optionalDependencies, devDependencies),
+    ) || getRuffVersionFromPoetryGroups(pyproject)
   );
-  if (version) return version;
+}
 
+function getRuffVersionFromPoetryGroups(
+  pyproject: Pyproject,
+): string | undefined {
   // Special handling for Poetry until it supports PEP 735
   // See: <https://github.com/python-poetry/poetry/issues/9751>
   const poetryGroups = Object.values(pyproject?.tool?.poetry?.group || {});

--- a/src/utils/pyproject.ts
+++ b/src/utils/pyproject.ts
@@ -54,7 +54,7 @@ function parsePyproject(pyprojectContent: string): string | undefined {
 
   // Special handling for Poetry until it supports PEP 735
   // See: <https://github.com/python-poetry/poetry/issues/9751>
-  const poetryGroups = Object.values(pyproject?.tool?.poetry?.group ?? {});
+  const poetryGroups = Object.values(pyproject?.tool?.poetry?.group || {});
   return poetryGroups
     .flatMap((group) => Object.entries(group.dependencies))
     .map(([name, spec]) => {

--- a/src/utils/pyproject.ts
+++ b/src/utils/pyproject.ts
@@ -23,22 +23,21 @@ function getRuffVersionFromAllDependencies(
   return undefined;
 }
 
+interface Pyproject {
+  project?: {
+    dependencies?: string[];
+    "optional-dependencies"?: Record<string, string[]>;
+  };
+  "dependency-groups"?: Record<string, Array<string | object>>;
+  tool?: {
+    poetry?: {
+      group?: Record<string, { dependencies: Record<string, string | object> }>;
+    };
+  };
+}
+
 function parsePyproject(pyprojectContent: string): string | undefined {
-  const pyproject: {
-    project?: {
-      dependencies?: string[];
-      "optional-dependencies"?: Record<string, string[]>;
-    };
-    "dependency-groups"?: Record<string, Array<string | object>>;
-    tool?: {
-      poetry?: {
-        group?: Record<
-          string,
-          { dependencies: Record<string, string | object> }
-        >;
-      };
-    };
-  } = toml.parse(pyprojectContent);
+  const pyproject: Pyproject = toml.parse(pyprojectContent);
   const dependencies: string[] = pyproject?.project?.dependencies || [];
   const optionalDependencies: string[] = Object.values(
     pyproject?.project?.["optional-dependencies"] || {},

--- a/src/utils/pyproject.ts
+++ b/src/utils/pyproject.ts
@@ -27,9 +27,17 @@ function parsePyproject(pyprojectContent: string): string | undefined {
   const pyproject: {
     project?: {
       dependencies?: string[];
-      "optional-dependencies"?: Map<string, string[]>;
+      "optional-dependencies"?: Record<string, string[]>;
     };
-    "dependency-groups"?: Map<string, Array<string | object>>;
+    "dependency-groups"?: Record<string, Array<string | object>>;
+    tool?: {
+      poetry?: {
+        group?: Record<
+          string,
+          { dependencies: Record<string, string | object> }
+        >;
+      };
+    };
   } = toml.parse(pyprojectContent);
   const dependencies: string[] = pyproject?.project?.dependencies || [];
   const optionalDependencies: string[] = Object.values(
@@ -40,9 +48,21 @@ function parsePyproject(pyprojectContent: string): string | undefined {
   )
     .flat()
     .filter((item: string | object) => typeof item === "string");
-  return getRuffVersionFromAllDependencies(
+  const version = getRuffVersionFromAllDependencies(
     dependencies.concat(optionalDependencies, devDependencies),
   );
+  if (version) return version;
+
+  // Special handling for Poetry until it supports PEP 735
+  // See: <https://github.com/python-poetry/poetry/issues/9751>
+  const poetryGroups = Object.values(pyproject?.tool?.poetry?.group ?? {});
+  return poetryGroups
+    .flatMap((group) => Object.entries(group.dependencies))
+    .map(([name, spec]) => {
+      if (name === "ruff" && typeof spec === "string") return spec;
+      return undefined;
+    })
+    .find((version) => version !== undefined);
 }
 
 export function getRuffVersionFromRequirementsFile(


### PR DESCRIPTION
Not sure if this is a desired feature since this was requested already (https://github.com/astral-sh/ruff-action/issues/40#issuecomment-2581207691) without any sort of response.
Unfortunately Poetry doesn't yet support PEP 735 (https://github.com/python-poetry/poetry/issues/9751) and it doesn't make sense to add ruff as a project dependency.