### PR TITLE
Fix test-pep440-version-specifier

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,15 +212,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install version 0.11.11
+      - name: Install version 0.9.10
         id: ruff-action
         uses: ./
         with:
-          version: ">=0.11.10,<0.12.0"
+          version: ">=0.9.9,<0.10.0"
           src: __tests__/fixtures/python-project
       - name: Correct version gets installed
         run: |
-          if [ "$RUFF_VERSION" != "0.11.11" ]; then
+          if [ "$RUFF_VERSION" != "0.9.10" ]; then
             exit 1
           fi
         env:


### PR DESCRIPTION
It makes no sense to expect a deterministic test when minor versions for 0.11.x are still getting released