### PR TITLE
chore(ci): address all lint findings

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@df559355d593797519d70b90fc8edd5db049e7a2 # v3.29.9
         with:
           languages: ${{ matrix.language }}
           source-root: src
@@ -55,7 +57,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@df559355d593797519d70b90fc8edd5db049e7a2 # v3.29.9
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -69,4 +71,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@df559355d593797519d70b90fc8edd5db049e7a2 # v3.29.9

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,6 +17,6 @@ jobs:
       pull-requests: read
     steps:
       - name: 🚀 Run Release Drafter
-        uses: release-drafter/release-drafter@v6.1.0
+        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Actionlint
         uses: eifinger/actionlint-action@23c85443d840cd73bbecb9cddfc933cc21649a38  # v1.9.1
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
       - run: |
@@ -38,7 +42,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, macos-14, windows-latest]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Use latest version
         uses: ./
         with:
@@ -51,7 +57,9 @@ jobs:
         ruff-version: ["0.1.7", "0.1.8", "0.4.7", "0.4.10", "0.7", "0.7.x", ">=0.7.0"]
         os: [ ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-14, windows-latest ]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Use version ${{ matrix.ruff-version }}
         uses: ./
         with:
@@ -60,7 +68,9 @@ jobs:
   test-unsupported-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Try install old version
         id: install
         continue-on-error: true
@@ -70,13 +80,17 @@ jobs:
           src: __tests__/fixtures/python-project
       - name: Check if the action failed
         run: |
-          if [ ${{ steps.install.outcome }} == "success" ]; then
+          if [ ${INSTALL_OUTCOME} == "success" ]; then
             exit 1
           fi
+        env:
+          INSTALL_OUTCOME: ${{ steps.install.outcome }}
   test-version-from-version-file-pyproject:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Use version from pyproject.toml
         id: ruff-action
         uses: ./
@@ -93,7 +107,9 @@ jobs:
   test-default-version-from-pyproject:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Use default version from pyproject.toml
         id: ruff-action
         uses: ./
@@ -109,7 +125,9 @@ jobs:
   test-default-version-from-pyproject-dev-group:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Use default version from pyproject.toml dev group
         id: ruff-action
         uses: ./
@@ -126,7 +144,9 @@ jobs:
   test-default-version-from-pyproject-dependency-groups:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Use default version from pyproject.toml dependency groups
         id: ruff-action
         uses: ./
@@ -143,7 +163,9 @@ jobs:
   test-default-version-from-pyproject-poetry-groups:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Use default version from pyproject.toml poetry group dependencies
         id: ruff-action
         uses: ./
@@ -160,7 +182,9 @@ jobs:
   test-default-version-from-pyproject-poetry:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Use default version from pyproject.toml poetry dependencies
         id: ruff-action
         uses: ./
@@ -177,7 +201,9 @@ jobs:
   test-default-version-from-pyproject-optional-dependencies:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Use default version from pyproject.toml optional dependencies
         id: ruff-action
         uses: ./
@@ -194,7 +220,9 @@ jobs:
   test-default-version-from-requirements:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Use default version from requirements.txt
         id: ruff-action
         uses: ./
@@ -211,7 +239,9 @@ jobs:
   test-semver-range:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Use version 0.7
         id: ruff-action
         uses: ./
@@ -228,7 +258,9 @@ jobs:
   test-pep440-version-specifier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Install version 0.9.10
         id: ruff-action
         uses: ./
@@ -252,7 +284,9 @@ jobs:
           - os: macos-latest
             checksum: "af9583bff12afbca5d5670334e0187dd60c4d91bc71317d1b2dde70cb1200ba9"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Checksum matches expected
         uses: ./
         with:
@@ -262,7 +296,9 @@ jobs:
   test-with-explicit-token:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Use default version
         uses: ./
         with:
@@ -274,7 +310,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Use args
         uses: ./
         with:
@@ -283,7 +321,9 @@ jobs:
   test-failure:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Format should fail
         id: format-should-fail
         continue-on-error: true
@@ -293,9 +333,11 @@ jobs:
           src: __tests__/fixtures/malformed-python-project
       - name: Check if the action failed
         run: |
-          if [ ${{ steps.format-should-fail.outcome }} == "success" ]; then
+          if [ ${FORMAT_SHOULD_FAIL_OUTCOME} == "success" ]; then
             exit 1
           fi
+        env:
+          FORMAT_SHOULD_FAIL_OUTCOME: ${{ steps.format-should-fail.outcome }}
       - name: Check should fail
         id: check-should-fail
         continue-on-error: true
@@ -304,16 +346,20 @@ jobs:
           src: __tests__/fixtures/malformed-python-project
       - name: Check if the action failed
         run: |
-          if [ ${{ steps.check-should-fail.outcome }} == "success" ]; then
+          if [ ${CHECK_SHOULD_FAIL_OUTCOME} == "success" ]; then
             exit 1
           fi
+        env:
+          CHECK_SHOULD_FAIL_OUTCOME: ${{ steps.check-should-fail.outcome }}
   test-multiple-src:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Use args
         uses: ./
         with:

--- a/.github/workflows/update-known-checksums.yml
+++ b/.github/workflows/update-known-checksums.yml
@@ -11,8 +11,10 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
       - name: Update known checksums

--- a/.github/workflows/update-major-minor-tags.yml
+++ b/.github/workflows/update-major-minor-tags.yml
@@ -16,7 +16,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Update Major Minor Tags
         run: |
           set -x


### PR DESCRIPTION
This addresses a variety of findings, mostly around overly broad default permissions and credential sharing.

I've also run [pinact](https://github.com/suzuki-shunsuke/pinact) to auto-hash-pin all action references -- Dependabot will still update these, but having them hash-pinned will seal off any undesirable tag/branch mutability 🙂 

(99% of these findings were done automatically with `zizmor --fix=all`, followed by verifying the results. I haven't added a [zizmor](https://docs.zizmor.sh) workflow as part of this PR, but I'd be happy to if desired.)