### PR TITLE
chore: use `npm ci --ignore-scripts` in CI and scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: "20"
       - run: |
-          npm install
+          npm ci --ignore-scripts
       - run: |
           npm run all
       - name: Check all jobs are in all-tests-passed.needs

--- a/.github/workflows/update-known-checksums.yml
+++ b/.github/workflows/update-known-checksums.yml
@@ -22,7 +22,7 @@ jobs:
         run:
           node dist/update-known-checksums/index.js
           src/download/checksum/known-checksums.ts ${{ secrets.GITHUB_TOKEN }}
-      - run: npm install && npm run all
+      - run: npm ci --ignore-scripts && npm run all
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412 # v7.0.9
         with:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "package": "ncc build -o dist/ruff-action src/ruff-action.ts && ncc build -o dist/update-known-checksums src/update-known-checksums.ts",
     "act": "act pull_request -W .github/workflows/test.yml --container-architecture linux/amd64 -s GITHUB_TOKEN=\"$(gh auth token)\"",
     "update-known-checksums": "RUNNER_TEMP=known_checksums node dist/update-known-checksums/index.js src/download/checksum/known-checksums.ts \"$(gh auth token)\"",
-    "all": "npm install && npm run build && npm run check && npm run package"
+    "all": "npm ci --ignore-scripts && npm run build && npm run check && npm run package"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Replaces various uses of `npm install` with `npm ci --ignore-scripts`. This should both be more hermetic (it'll always use the locked versions rather than re-resolving) and will partially mitigate some build-time code execution risk. 

There should be no breakage risk, as the current dependency footprint is small and shouldn't include anything that uses build scripts 🙂 