### PR TITLE
Update the ruff-format matcher to properly extract all info

### DIFF
--- a/.github/matchers/format.json
+++ b/.github/matchers/format.json
@@ -4,9 +4,15 @@
       "owner": "ruff-format",
       "pattern": [
         {
-          "file": 2,
-          "message": 1,
-          "regexp": "^(Would reformat):\\s*(.+)$"
+          "code": 2,
+          "column": 5,
+          "endColumn": 7,
+          "endLine": 6,
+          "file": 3,
+          "line": 4,
+          "message": 8,
+          "regexp": "^(?:(error|warning|notice))\\s+title=([^,]+),file=([^,]+),line=(\\d+),col=(\\d+)(?:,endLine=(\\d+))?(?:,endColumn=(\\d+))?::(.+)$",
+          "severity": 1
         }
       ]
     }


### PR DESCRIPTION
Now that format also supports the github output format all info is available