### PR TITLE
Fix: Update RUFF_VERSION check to 0.14.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
           src: __tests__/fixtures/python-project
       - name: Correct version gets installed
         run: |
-          if [ "$RUFF_VERSION" != "0.6.2" ]; then
+          if [ "$RUFF_VERSION" != "0.14.11" ]; then
             exit 1
           fi
         env:


### PR DESCRIPTION
When using `version: latest` in workflows, the installed ruff version may differ from the hardcoded version checks. This fixes the issue by updating version checks to use 0.14.11, which is the latest version in known-checksums.ts.