### PR TITLE
GitHub actions summary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ anything `ruff` can (ex, fix).
 | `src`           | Source path(s) to run `ruff` on. Supports glob patterns.                                                                                   | [github.workspace] |
 | `checksum`      | The sha256 checksum of the downloaded artifact.                                                                                            | None               |
 | `github-token`  | The GitHub token to use when downloading Ruff release artifacts from GitHub.                                                               | `GITHUB_TOKEN`     |
+| `summary`       | Write the results of Ruff to the GitHub Actions step summary.                                                                              | `true`             |
 
 By default, Ruff version metadata is resolved from the
 [`astral-sh/versions` Ruff manifest](https://github.com/astral-sh/versions/blob/main/v1/ruff.ndjson).

--- a/__tests__/utils/annotations.test.ts
+++ b/__tests__/utils/annotations.test.ts
@@ -1,12 +1,22 @@
 import { describe, expect, it } from "@jest/globals";
-import { formatAnnotationsForSummary } from "../../src/utils/annotations";
+import {
+  AnnotationParser,
+  formatAnnotationsForSummary,
+} from "../../src/utils/annotations";
 
 describe("formatAnnotationsForSummary", () => {
   it("should parse a single annotation line into human-readable format", () => {
-    const input =
+    // Without prefix duplication
+    const input1 =
       "::error file=src/main.py,line=10,col=5,title=Ruff (E501)::Line too long";
-    const expected = "src/main.py:10:5: E501 Line too long";
-    expect(formatAnnotationsForSummary(input)).toBe(expected);
+    const expected1 = "src/main.py:10:5: E501 Line too long";
+    expect(formatAnnotationsForSummary(input1)).toBe(expected1);
+
+    // With prefix duplication and endLine/endColumn parameters
+    const input2 =
+      "::error title=ruff (E501),file=src/main.py,line=10,col=5,endLine=10,endColumn=90::src/main.py:10:5: E501 Line too long";
+    const expected2 = "src/main.py:10:5: E501 Line too long";
+    expect(formatAnnotationsForSummary(input2)).toBe(expected2);
   });
 
   it("should parse multiple annotation lines, preserving order", () => {
@@ -70,5 +80,45 @@ describe("formatAnnotationsForSummary", () => {
   it("should handle empty or whitespace-only input", () => {
     expect(formatAnnotationsForSummary("")).toBe("");
     expect(formatAnnotationsForSummary("   \n  ")).toBe("");
+  });
+});
+
+describe("AnnotationParser", () => {
+  it("should process input incrementally in chunks", () => {
+    const parser = new AnnotationParser();
+    parser.append("::error file=src/main.py,line=10,c");
+    parser.append("ol=5,title=Ruff (E501)::Line too ");
+    parser.append("long\n::warning file=src/utils.py,line=2");
+    parser.append("0,col=1,title=Ruff (F401)::Unused import\n");
+    parser.flush();
+
+    const expected = [
+      "src/main.py:10:5: E501 Line too long",
+      "src/utils.py:20:1: F401 Unused import",
+    ].join("\n");
+    expect(parser.getSummary()).toBe(expected);
+  });
+
+  it("should truncate and report accurate truncated character count when exceeding max limit", () => {
+    const parser = new AnnotationParser();
+    // Feed small lines, then a huge chunk to exceed 100k limit.
+    const chunk1 = "Some initial line\n";
+    const chunk2 = `${"a".repeat(110000)}\n`;
+    const chunk3 = "Another line after truncation";
+
+    parser.append(chunk1);
+    parser.append(chunk2);
+    parser.append(chunk3);
+    parser.flush();
+
+    const summary = parser.getSummary();
+    expect(summary.length).toBeLessThan(110000);
+    expect(summary).toContain("... (truncated, ");
+
+    // Check that the suffix lists correct count
+    const match = summary.match(/\(truncated, (\d+) more characters\)/);
+    expect(match).not.toBeNull();
+    const truncatedCount = Number(match?.[1]);
+    expect(truncatedCount).toBeGreaterThan(0);
   });
 });

--- a/__tests__/utils/annotations.test.ts
+++ b/__tests__/utils/annotations.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "@jest/globals";
+import { formatAnnotationsForSummary } from "../../src/utils/annotations";
+
+describe("formatAnnotationsForSummary", () => {
+  it("should parse a single annotation line into human-readable format", () => {
+    const input =
+      "::error file=src/main.py,line=10,col=5,title=Ruff (E501)::Line too long";
+    const expected = "src/main.py:10:5: E501 Line too long";
+    expect(formatAnnotationsForSummary(input)).toBe(expected);
+  });
+
+  it("should parse multiple annotation lines, preserving order", () => {
+    const input = [
+      "::error file=src/main.py,line=10,col=5,title=Ruff (E501)::Line too long",
+      "::warning file=src/utils.py,line=20,col=1,title=Ruff (F401)::Unused import",
+    ].join("\n");
+    const expected = [
+      "src/main.py:10:5: E501 Line too long",
+      "src/utils.py:20:1: F401 Unused import",
+    ].join("\n");
+    expect(formatAnnotationsForSummary(input)).toBe(expected);
+  });
+
+  it("should parse annotation lines with different parameter order", () => {
+    const input =
+      "::error title=Ruff (E501),file=src/main.py,line=10,col=5::Line too long";
+    const expected = "src/main.py:10:5: E501 Line too long";
+    expect(formatAnnotationsForSummary(input)).toBe(expected);
+  });
+
+  it("should handle when title has no code in parentheses", () => {
+    const input =
+      "::error file=src/main.py,line=10,col=5,title=Ruff::Line too long";
+    const expected = "src/main.py:10:5: Line too long";
+    expect(formatAnnotationsForSummary(input)).toBe(expected);
+  });
+
+  it("should handle when title is missing", () => {
+    const input = "::error file=src/main.py,line=10,col=5::Line too long";
+    const expected = "src/main.py:10:5: Line too long";
+    expect(formatAnnotationsForSummary(input)).toBe(expected);
+  });
+
+  it("should handle when file/line/col are missing", () => {
+    const input = "::error title=Ruff::General failure";
+    const expected = "General failure";
+    expect(formatAnnotationsForSummary(input)).toBe(expected);
+  });
+
+  it("should pass through non-annotation lines unchanged", () => {
+    const input =
+      "Some general log output\n::error file=src/main.py,line=10,col=5,title=Ruff::Line too long\nAnother log";
+    const expected =
+      "Some general log output\nsrc/main.py:10:5: Line too long\nAnother log";
+    expect(formatAnnotationsForSummary(input)).toBe(expected);
+  });
+
+  it("should fall back gracefully to raw input if there are unmatched commands and no matched annotations", () => {
+    const input = "::some-unrelated-command param=1";
+    expect(formatAnnotationsForSummary(input)).toBe(input);
+  });
+
+  it("should truncate output if it exceeds character limit", () => {
+    const longLine = "a".repeat(110000);
+    const result = formatAnnotationsForSummary(longLine);
+    expect(result.length).toBeLessThan(110000);
+    expect(result).toContain("... (truncated");
+  });
+
+  it("should handle empty or whitespace-only input", () => {
+    expect(formatAnnotationsForSummary("")).toBe("");
+    expect(formatAnnotationsForSummary("   \n  ")).toBe("");
+  });
+});

--- a/__tests__/utils/annotations.test.ts
+++ b/__tests__/utils/annotations.test.ts
@@ -1,18 +1,22 @@
 import { describe, expect, it } from "@jest/globals";
-import {
-  AnnotationParser,
-  formatAnnotationsForSummary,
-} from "../../src/utils/annotations";
+import { AnnotationParser } from "../../src/utils/annotations";
+
+function formatAnnotationsForSummary(raw: string): string {
+  const parser = new AnnotationParser();
+  parser.append(raw);
+  parser.flush();
+  return parser.getSummary();
+}
 
 describe("formatAnnotationsForSummary", () => {
   it("should parse a single annotation line into human-readable format", () => {
-    // Without prefix duplication
+    // Synthetic/standard workflow annotation line without message prefix duplication
     const input1 =
       "::error file=src/main.py,line=10,col=5,title=Ruff (E501)::Line too long";
     const expected1 = "src/main.py:10:5: E501 Line too long";
     expect(formatAnnotationsForSummary(input1)).toBe(expected1);
 
-    // With prefix duplication and endLine/endColumn parameters
+    // Verbatim ruff --output-format=github line (includes prefix duplication & endLine/endColumn)
     const input2 =
       "::error title=ruff (E501),file=src/main.py,line=10,col=5,endLine=10,endColumn=90::src/main.py:10:5: E501 Line too long";
     const expected2 = "src/main.py:10:5: E501 Line too long";

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
       "Used for authenticated downloads of Ruff release artifacts from GitHub."
     required: false
     default: ${{ github.token }}
+  summary:
+    description: "Add the output of Ruff to the GitHub Actions step summary."
+    required: false
+    default: "true"
 outputs:
   ruff-version:
     description: "The installed ruff version. Useful when using latest."

--- a/dist/ruff-action/index.cjs
+++ b/dist/ruff-action/index.cjs
@@ -23412,6 +23412,7 @@ var Summary = class {
   }
 };
 var _summary = new Summary();
+var summary = _summary;
 
 // node_modules/@actions/core/lib/platform.js
 var import_os2 = __toESM(require("os"), 1);
@@ -28311,6 +28312,60 @@ function getExtension(platform2) {
   return platform2 === "pc-windows-msvc" ? ".zip" : ".tar.gz";
 }
 
+// src/utils/annotations.ts
+var COMMAND_RE = /^::(?:error|warning)\s+(.*?)::(.*)$/;
+function formatAnnotationsForSummary(raw) {
+  const lines = raw.split(/\r?\n/);
+  const formatted = [];
+  let unmatchedCommandLines = 0;
+  for (const line of lines) {
+    const match3 = line.match(COMMAND_RE);
+    if (match3) {
+      const [, paramStr, message] = match3;
+      const params = {};
+      for (const pair of paramStr.split(",")) {
+        const eqIdx = pair.indexOf("=");
+        if (eqIdx !== -1) {
+          const key = pair.substring(0, eqIdx).trim();
+          const val = pair.substring(eqIdx + 1).trim();
+          params[key] = val;
+        }
+      }
+      const file = params.file || "";
+      const lineNo = params.line || "";
+      const col = params.col || "";
+      const title = params.title || "";
+      let code = "";
+      if (title) {
+        const codeMatch = title.match(/\(([^)]+)\)/);
+        if (codeMatch) {
+          code = `${codeMatch[1]} `;
+        }
+      }
+      if (file && lineNo) {
+        const colStr = col ? `:${col}` : "";
+        formatted.push(`${file}:${lineNo}${colStr}: ${code}${message}`);
+      } else {
+        formatted.push(`${code}${message}`);
+      }
+    } else if (line.startsWith("::")) {
+      unmatchedCommandLines++;
+    } else if (line.trim()) {
+      formatted.push(line);
+    }
+  }
+  if (unmatchedCommandLines > 0 && formatted.length === 0) {
+    return raw;
+  }
+  return truncate(formatted.join("\n"), 1e5);
+}
+function truncate(text, maxChars) {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars)}
+
+... (truncated, ${text.length - maxChars} more characters)`;
+}
+
 // src/utils/inputs.ts
 var version = getInput("version");
 var checkSum = getInput("checksum");
@@ -28323,6 +28378,7 @@ var downloadFromAstralMirror = getBooleanInput2(
   "download-from-astral-mirror",
   true
 );
+var summary2 = getBooleanInput2("summary", true);
 function getBooleanInput2(name, defaultValue) {
   if (getInput(name) === "") {
     return defaultValue;
@@ -32064,8 +32120,19 @@ async function run() {
     addMatchers();
     setOutput("ruff-version", setupResult.version);
     info(`Successfully installed ruff version ${setupResult.version}`);
-    await runRuff(path14.join(setupResult.ruffDir, "ruff"), args, src);
-    process.exit(0);
+    const { exitCode, output } = await runRuff(
+      path14.join(setupResult.ruffDir, "ruff"),
+      args,
+      src
+    );
+    if (summary2) {
+      const summaryText = formatAnnotationsForSummary(output);
+      await summary.addHeading("Ruff Output").addCodeBlock(summaryText || "No issues found.", "text").write();
+    }
+    if (exitCode !== 0) {
+      setFailed(`Ruff failed with exit code ${exitCode}`);
+    }
+    process.exit(exitCode);
   } catch (err) {
     setFailed(err.message);
   }
@@ -32133,7 +32200,20 @@ function getActionRoot() {
 }
 async function runRuff(ruffExecutablePath, args2, src2) {
   const execArgs = [...splitInput(args2), ...await expandSourceInput(src2)];
-  await exec(ruffExecutablePath, execArgs);
+  let output = "";
+  const options = {
+    ignoreReturnCode: true,
+    listeners: {
+      stderr: (data) => {
+        output += data.toString();
+      },
+      stdout: (data) => {
+        output += data.toString();
+      }
+    }
+  };
+  const exitCode = await exec(ruffExecutablePath, execArgs, options);
+  return { exitCode, output };
 }
 run();
 /*! Bundled license information:

--- a/dist/ruff-action/index.cjs
+++ b/dist/ruff-action/index.cjs
@@ -14668,7 +14668,7 @@ var require_util4 = __commonJS({
     var { getEncoding } = require_encoding();
     var { serializeAMimeType, parseMIMEType } = require_data_url();
     var { types: types2 } = require("node:util");
-    var { StringDecoder } = require("string_decoder");
+    var { StringDecoder: StringDecoder2 } = require("string_decoder");
     var { btoa } = require("node:buffer");
     var staticPropertyDescriptors = {
       enumerable: true,
@@ -14759,7 +14759,7 @@ var require_util4 = __commonJS({
             dataURL += serializeAMimeType(parsed);
           }
           dataURL += ";base64,";
-          const decoder = new StringDecoder("latin1");
+          const decoder = new StringDecoder2("latin1");
           for (const chunk of bytes) {
             dataURL += btoa(decoder.write(chunk));
           }
@@ -14788,7 +14788,7 @@ var require_util4 = __commonJS({
         }
         case "BinaryString": {
           let binaryString = "";
-          const decoder = new StringDecoder("latin1");
+          const decoder = new StringDecoder2("latin1");
           for (const chunk of bytes) {
             binaryString += decoder.write(chunk);
           }
@@ -22317,6 +22317,7 @@ var require_pep440 = __commonJS({
 
 // src/ruff-action.ts
 var path14 = __toESM(require("node:path"), 1);
+var import_node_string_decoder = require("node:string_decoder");
 
 // node_modules/@actions/core/lib/command.js
 var os = __toESM(require("os"), 1);
@@ -28314,11 +28315,31 @@ function getExtension(platform2) {
 
 // src/utils/annotations.ts
 var COMMAND_RE = /^::(?:error|warning)\s+(.*?)::(.*)$/;
-function formatAnnotationsForSummary(raw) {
-  const lines = raw.split(/\r?\n/);
-  const formatted = [];
-  let unmatchedCommandLines = 0;
-  for (const line of lines) {
+var MAX_SUMMARY_CHARS = 1e5;
+var AnnotationParser = class {
+  buffer = "";
+  formatted = [];
+  unmatchedCommandLines = 0;
+  rawChunks = [];
+  rawLength = 0;
+  rawTruncatedChars = 0;
+  formattedLength = 0;
+  formattedTruncatedChars = 0;
+  append(chunk) {
+    this.buffer += chunk;
+    const lines = this.buffer.split(/\r?\n/);
+    this.buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      this.processLine(line);
+    }
+  }
+  flush() {
+    if (this.buffer) {
+      this.processLine(this.buffer);
+      this.buffer = "";
+    }
+  }
+  processLine(line) {
     const match3 = line.match(COMMAND_RE);
     if (match3) {
       const [, paramStr, message] = match3;
@@ -28342,29 +28363,68 @@ function formatAnnotationsForSummary(raw) {
           code = `${codeMatch[1]} `;
         }
       }
+      let cleanedMessage = message;
       if (file && lineNo) {
-        const colStr = col ? `:${col}` : "";
-        formatted.push(`${file}:${lineNo}${colStr}: ${code}${message}`);
-      } else {
-        formatted.push(`${code}${message}`);
+        const prefixWithCode = `${file}:${lineNo}${col ? `:${col}` : ""}: ${code}`;
+        const prefixWithoutCode = `${file}:${lineNo}${col ? `:${col}` : ""}: `;
+        if (cleanedMessage.startsWith(prefixWithCode)) {
+          cleanedMessage = cleanedMessage.slice(prefixWithCode.length);
+        } else if (cleanedMessage.startsWith(prefixWithoutCode)) {
+          cleanedMessage = cleanedMessage.slice(prefixWithoutCode.length);
+        }
       }
+      const formattedLine = file && lineNo ? `${file}:${lineNo}${col ? `:${col}` : ""}: ${code}${cleanedMessage}` : `${code}${cleanedMessage}`;
+      this.addFormatted(formattedLine);
     } else if (line.startsWith("::")) {
-      unmatchedCommandLines++;
+      this.unmatchedCommandLines++;
+      this.addRaw(line);
     } else if (line.trim()) {
-      formatted.push(line);
+      this.addFormatted(line);
+    } else {
+      this.addRaw(line);
     }
   }
-  if (unmatchedCommandLines > 0 && formatted.length === 0) {
-    return raw;
+  addFormatted(line) {
+    if (this.formattedLength < MAX_SUMMARY_CHARS) {
+      this.formatted.push(line);
+      this.formattedLength += line.length + (this.formatted.length > 1 ? 1 : 0);
+    } else {
+      this.formattedTruncatedChars += line.length + 1;
+    }
+    this.addRaw(line);
   }
-  return truncate(formatted.join("\n"), 1e5);
-}
-function truncate(text, maxChars) {
-  if (text.length <= maxChars) return text;
-  return `${text.slice(0, maxChars)}
+  addRaw(line) {
+    if (this.rawLength < MAX_SUMMARY_CHARS) {
+      this.rawChunks.push(line);
+      this.rawLength += line.length + (this.rawChunks.length > 1 ? 1 : 0);
+    } else {
+      this.rawTruncatedChars += line.length + 1;
+    }
+  }
+  getSummary() {
+    if (this.unmatchedCommandLines > 0 && this.formatted.length === 0) {
+      return this.truncate(
+        this.rawChunks.join("\n"),
+        MAX_SUMMARY_CHARS,
+        this.rawTruncatedChars
+      );
+    }
+    return this.truncate(
+      this.formatted.join("\n"),
+      MAX_SUMMARY_CHARS,
+      this.formattedTruncatedChars
+    );
+  }
+  truncate(text, maxChars, truncatedCount) {
+    const totalTruncated = Math.max(0, text.length - maxChars) + truncatedCount;
+    if (totalTruncated === 0) {
+      return text;
+    }
+    return `${text.slice(0, maxChars)}
 
-... (truncated, ${text.length - maxChars} more characters)`;
-}
+... (truncated, ${totalTruncated} more characters)`;
+  }
+};
 
 // src/utils/inputs.ts
 var version = getInput("version");
@@ -32120,14 +32180,14 @@ async function run() {
     addMatchers();
     setOutput("ruff-version", setupResult.version);
     info(`Successfully installed ruff version ${setupResult.version}`);
-    const { exitCode, output } = await runRuff(
+    const { exitCode, summaryText } = await runRuff(
       path14.join(setupResult.ruffDir, "ruff"),
       args,
       src
     );
     if (summary2) {
-      const summaryText = formatAnnotationsForSummary(output);
-      await summary.addHeading("Ruff Output").addCodeBlock(summaryText || "No issues found.", "text").write();
+      const sanitizedSummaryText = summaryText.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+      await summary.addHeading("Ruff Output").addCodeBlock(sanitizedSummaryText || "No issues found.", "text").write();
     }
     if (exitCode !== 0) {
       setFailed(`Ruff failed with exit code ${exitCode}`);
@@ -32200,20 +32260,27 @@ function getActionRoot() {
 }
 async function runRuff(ruffExecutablePath, args2, src2) {
   const execArgs = [...splitInput(args2), ...await expandSourceInput(src2)];
-  let output = "";
+  const parser = summary2 ? new AnnotationParser() : void 0;
+  const stdoutDecoder = new import_node_string_decoder.StringDecoder("utf8");
+  const stderrDecoder = new import_node_string_decoder.StringDecoder("utf8");
   const options = {
     ignoreReturnCode: true,
     listeners: {
       stderr: (data) => {
-        output += data.toString();
+        parser?.append(stderrDecoder.write(data));
       },
       stdout: (data) => {
-        output += data.toString();
+        parser?.append(stdoutDecoder.write(data));
       }
     }
   };
   const exitCode = await exec(ruffExecutablePath, execArgs, options);
-  return { exitCode, output };
+  if (parser) {
+    parser.append(stdoutDecoder.end());
+    parser.append(stderrDecoder.end());
+    parser.flush();
+  }
+  return { exitCode, summaryText: parser?.getSummary() ?? "" };
 }
 run();
 /*! Bundled license information:

--- a/src/ruff-action.ts
+++ b/src/ruff-action.ts
@@ -6,6 +6,7 @@ import {
   downloadVersion,
   tryGetFromToolCache,
 } from "./download/download-version";
+import { formatAnnotationsForSummary } from "./utils/annotations";
 import {
   args,
   checkSum,
@@ -13,6 +14,7 @@ import {
   githubToken,
   manifestFile,
   src,
+  summary,
   version,
   versionFile as versionFileInput,
 } from "./utils/inputs";
@@ -54,9 +56,24 @@ async function run(): Promise<void> {
     core.setOutput("ruff-version", setupResult.version);
     core.info(`Successfully installed ruff version ${setupResult.version}`);
 
-    await runRuff(path.join(setupResult.ruffDir, "ruff"), args, src);
+    const { exitCode, output } = await runRuff(
+      path.join(setupResult.ruffDir, "ruff"),
+      args,
+      src,
+    );
 
-    process.exit(0);
+    if (summary) {
+      const summaryText = formatAnnotationsForSummary(output);
+      await core.summary
+        .addHeading("Ruff Output")
+        .addCodeBlock(summaryText || "No issues found.", "text")
+        .write();
+    }
+
+    if (exitCode !== 0) {
+      core.setFailed(`Ruff failed with exit code ${exitCode}`);
+    }
+    process.exit(exitCode);
   } catch (err) {
     core.setFailed((err as Error).message);
   }
@@ -141,9 +158,22 @@ async function runRuff(
   ruffExecutablePath: string,
   args: string,
   src: string,
-): Promise<void> {
+): Promise<{ exitCode: number; output: string }> {
   const execArgs = [...splitInput(args), ...(await expandSourceInput(src))];
-  await exec.exec(ruffExecutablePath, execArgs);
+  let output = "";
+  const options: exec.ExecOptions = {
+    ignoreReturnCode: true,
+    listeners: {
+      stderr: (data: Buffer) => {
+        output += data.toString();
+      },
+      stdout: (data: Buffer) => {
+        output += data.toString();
+      },
+    },
+  };
+  const exitCode = await exec.exec(ruffExecutablePath, execArgs, options);
+  return { exitCode, output };
 }
 
 run();

--- a/src/ruff-action.ts
+++ b/src/ruff-action.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import * as core from "@actions/core";
 import * as exec from "@actions/exec";
 import * as semver from "semver";
@@ -6,7 +7,7 @@ import {
   downloadVersion,
   tryGetFromToolCache,
 } from "./download/download-version";
-import { formatAnnotationsForSummary } from "./utils/annotations";
+import { AnnotationParser } from "./utils/annotations";
 import {
   args,
   checkSum,
@@ -56,17 +57,21 @@ async function run(): Promise<void> {
     core.setOutput("ruff-version", setupResult.version);
     core.info(`Successfully installed ruff version ${setupResult.version}`);
 
-    const { exitCode, output } = await runRuff(
+    const { exitCode, summaryText } = await runRuff(
       path.join(setupResult.ruffDir, "ruff"),
       args,
       src,
     );
 
     if (summary) {
-      const summaryText = formatAnnotationsForSummary(output);
+      const sanitizedSummaryText = summaryText
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+
       await core.summary
         .addHeading("Ruff Output")
-        .addCodeBlock(summaryText || "No issues found.", "text")
+        .addCodeBlock(sanitizedSummaryText || "No issues found.", "text")
         .write();
     }
 
@@ -158,22 +163,29 @@ async function runRuff(
   ruffExecutablePath: string,
   args: string,
   src: string,
-): Promise<{ exitCode: number; output: string }> {
+): Promise<{ exitCode: number; summaryText: string }> {
   const execArgs = [...splitInput(args), ...(await expandSourceInput(src))];
-  let output = "";
+  const parser = summary ? new AnnotationParser() : undefined;
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
   const options: exec.ExecOptions = {
     ignoreReturnCode: true,
     listeners: {
       stderr: (data: Buffer) => {
-        output += data.toString();
+        parser?.append(stderrDecoder.write(data));
       },
       stdout: (data: Buffer) => {
-        output += data.toString();
+        parser?.append(stdoutDecoder.write(data));
       },
     },
   };
   const exitCode = await exec.exec(ruffExecutablePath, execArgs, options);
-  return { exitCode, output };
+  if (parser) {
+    parser.append(stdoutDecoder.end());
+    parser.append(stderrDecoder.end());
+    parser.flush();
+  }
+  return { exitCode, summaryText: parser?.getSummary() ?? "" };
 }
 
 run();

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -128,9 +128,3 @@ export class AnnotationParser {
   }
 }
 
-export function formatAnnotationsForSummary(raw: string): string {
-  const parser = new AnnotationParser();
-  parser.append(raw);
-  parser.flush();
-  return parser.getSummary();
-}

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -1,11 +1,33 @@
 const COMMAND_RE = /^::(?:error|warning)\s+(.*?)::(.*)$/;
+const MAX_SUMMARY_CHARS = 100000;
 
-export function formatAnnotationsForSummary(raw: string): string {
-  const lines = raw.split(/\r?\n/);
-  const formatted: string[] = [];
-  let unmatchedCommandLines = 0;
+export class AnnotationParser {
+  private buffer = "";
+  readonly formatted: string[] = [];
+  unmatchedCommandLines = 0;
+  private rawChunks: string[] = [];
+  private rawLength = 0;
+  private rawTruncatedChars = 0;
+  private formattedLength = 0;
+  private formattedTruncatedChars = 0;
 
-  for (const line of lines) {
+  public append(chunk: string): void {
+    this.buffer += chunk;
+    const lines = this.buffer.split(/\r?\n/);
+    this.buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      this.processLine(line);
+    }
+  }
+
+  public flush(): void {
+    if (this.buffer) {
+      this.processLine(this.buffer);
+      this.buffer = "";
+    }
+  }
+
+  private processLine(line: string): void {
     const match = line.match(COMMAND_RE);
     if (match) {
       const [, paramStr, message] = match;
@@ -31,27 +53,84 @@ export function formatAnnotationsForSummary(raw: string): string {
         }
       }
 
+      let cleanedMessage = message;
       if (file && lineNo) {
-        const colStr = col ? `:${col}` : "";
-        formatted.push(`${file}:${lineNo}${colStr}: ${code}${message}`);
-      } else {
-        formatted.push(`${code}${message}`);
+        const prefixWithCode = `${file}:${lineNo}${col ? `:${col}` : ""}: ${code}`;
+        const prefixWithoutCode = `${file}:${lineNo}${col ? `:${col}` : ""}: `;
+        if (cleanedMessage.startsWith(prefixWithCode)) {
+          cleanedMessage = cleanedMessage.slice(prefixWithCode.length);
+        } else if (cleanedMessage.startsWith(prefixWithoutCode)) {
+          cleanedMessage = cleanedMessage.slice(prefixWithoutCode.length);
+        }
       }
+
+      const formattedLine =
+        file && lineNo
+          ? `${file}:${lineNo}${col ? `:${col}` : ""}: ${code}${cleanedMessage}`
+          : `${code}${cleanedMessage}`;
+
+      this.addFormatted(formattedLine);
     } else if (line.startsWith("::")) {
-      unmatchedCommandLines++;
+      this.unmatchedCommandLines++;
+      this.addRaw(line);
     } else if (line.trim()) {
-      formatted.push(line);
+      this.addFormatted(line);
+    } else {
+      this.addRaw(line);
     }
   }
 
-  if (unmatchedCommandLines > 0 && formatted.length === 0) {
-    return raw;
+  private addFormatted(line: string): void {
+    if (this.formattedLength < MAX_SUMMARY_CHARS) {
+      this.formatted.push(line);
+      this.formattedLength += line.length + (this.formatted.length > 1 ? 1 : 0);
+    } else {
+      this.formattedTruncatedChars += line.length + 1;
+    }
+    this.addRaw(line);
   }
 
-  return truncate(formatted.join("\n"), 100000);
+  private addRaw(line: string): void {
+    if (this.rawLength < MAX_SUMMARY_CHARS) {
+      this.rawChunks.push(line);
+      this.rawLength += line.length + (this.rawChunks.length > 1 ? 1 : 0);
+    } else {
+      this.rawTruncatedChars += line.length + 1;
+    }
+  }
+
+  public getSummary(): string {
+    if (this.unmatchedCommandLines > 0 && this.formatted.length === 0) {
+      return this.truncate(
+        this.rawChunks.join("\n"),
+        MAX_SUMMARY_CHARS,
+        this.rawTruncatedChars,
+      );
+    }
+
+    return this.truncate(
+      this.formatted.join("\n"),
+      MAX_SUMMARY_CHARS,
+      this.formattedTruncatedChars,
+    );
+  }
+
+  private truncate(
+    text: string,
+    maxChars: number,
+    truncatedCount: number,
+  ): string {
+    const totalTruncated = Math.max(0, text.length - maxChars) + truncatedCount;
+    if (totalTruncated === 0) {
+      return text;
+    }
+    return `${text.slice(0, maxChars)}\n\n... (truncated, ${totalTruncated} more characters)`;
+  }
 }
 
-function truncate(text: string, maxChars: number): string {
-  if (text.length <= maxChars) return text;
-  return `${text.slice(0, maxChars)}\n\n... (truncated, ${text.length - maxChars} more characters)`;
+export function formatAnnotationsForSummary(raw: string): string {
+  const parser = new AnnotationParser();
+  parser.append(raw);
+  parser.flush();
+  return parser.getSummary();
 }

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -1,0 +1,57 @@
+const COMMAND_RE = /^::(?:error|warning)\s+(.*?)::(.*)$/;
+
+export function formatAnnotationsForSummary(raw: string): string {
+  const lines = raw.split(/\r?\n/);
+  const formatted: string[] = [];
+  let unmatchedCommandLines = 0;
+
+  for (const line of lines) {
+    const match = line.match(COMMAND_RE);
+    if (match) {
+      const [, paramStr, message] = match;
+      const params: Record<string, string> = {};
+      for (const pair of paramStr.split(",")) {
+        const eqIdx = pair.indexOf("=");
+        if (eqIdx !== -1) {
+          const key = pair.substring(0, eqIdx).trim();
+          const val = pair.substring(eqIdx + 1).trim();
+          params[key] = val;
+        }
+      }
+      const file = params.file || "";
+      const lineNo = params.line || "";
+      const col = params.col || "";
+      const title = params.title || "";
+
+      let code = "";
+      if (title) {
+        const codeMatch = title.match(/\(([^)]+)\)/);
+        if (codeMatch) {
+          code = `${codeMatch[1]} `;
+        }
+      }
+
+      if (file && lineNo) {
+        const colStr = col ? `:${col}` : "";
+        formatted.push(`${file}:${lineNo}${colStr}: ${code}${message}`);
+      } else {
+        formatted.push(`${code}${message}`);
+      }
+    } else if (line.startsWith("::")) {
+      unmatchedCommandLines++;
+    } else if (line.trim()) {
+      formatted.push(line);
+    }
+  }
+
+  if (unmatchedCommandLines > 0 && formatted.length === 0) {
+    return raw;
+  }
+
+  return truncate(formatted.join("\n"), 100000);
+}
+
+function truncate(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars)}\n\n... (truncated, ${text.length - maxChars} more characters)`;
+}

--- a/src/utils/inputs.ts
+++ b/src/utils/inputs.ts
@@ -11,6 +11,7 @@ export const downloadFromAstralMirror = getBooleanInput(
   "download-from-astral-mirror",
   true,
 );
+export const summary = getBooleanInput("summary", true);
 
 function getBooleanInput(name: string, defaultValue: boolean): boolean {
   if (core.getInput(name) === "") {


### PR DESCRIPTION
Adds a `summary` input (default: `true`) that writes Ruff's output to the GitHub Actions step summary after each run.

The action already runs Ruff in `--output-format=github` mode, so rather than adding a second invocation or stripping ANSI codes, this captures the existing `::error`/`::warning` annotation lines and reformats them into human-readable `file:line:col: CODE message` text for the summary. Output is truncated at 100,000 characters to stay within GitHub's step summary size limit. If no issues are found, the summary displays "No issues found."

Existing annotation behavior (inline PR diff annotations and problem matchers) is unchanged -`setOutputFormat()` and `addMatchers()` are still called exactly as before.

To disable the summary:
```yaml
- uses: astral-sh/ruff-action@v4
  with:
    summary: "false"
```

This closes #290 