### PR TITLE
Add npm dependency cooldown

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
Follows #400 -- we should also enforce a cooldown (but a shorter one) on the development tool side.